### PR TITLE
Shorten coord transform section

### DIFF
--- a/4-reduction/coord-transforms.ipynb
+++ b/4-reduction/coord-transforms.ipynb
@@ -42,9 +42,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d8d483d8-971b-4122-81ab-7b96964daef9",
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
    "outputs": [],
    "source": [
+    "# elastic_data\n",
     "source_position = sc.vector([0.0, 0.0, -10.0], unit=\"m\")\n",
     "sample_position = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
     "position = sc.vectors(\n",
@@ -57,7 +62,7 @@
     "    unit=\"m\",\n",
     ")\n",
     "\n",
-    "data = sc.DataArray(\n",
+    "elastic_data = sc.DataArray(\n",
     "    sc.ones(sizes={\"position\": 3}),\n",
     "    coords={\n",
     "        \"source_position\": source_position,\n",
@@ -65,7 +70,44 @@
     "        \"position\": position,\n",
     "    },\n",
     ")\n",
-    "data"
+    "elastic_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b868ac26-a077-4a10-8777-b0ac4b1071c8",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# qens_data\n",
+    "source_position = sc.vector([0.0, 0.0, -10.0], unit=\"m\")\n",
+    "sample_position = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
+    "analyzer_position = sc.vector([0.0, 1.0, 1.0], unit=\"m\")\n",
+    "position = sc.vectors(\n",
+    "    dims=[\"position\"],\n",
+    "    values=[\n",
+    "        [0.0, 1.9, 0.0],\n",
+    "        [0.0, 2.0, 0.0],\n",
+    "        [0.0, 2.1, 0.0],\n",
+    "    ],\n",
+    "    unit=\"m\",\n",
+    ")\n",
+    "\n",
+    "qens_data = sc.DataArray(\n",
+    "    sc.ones(sizes={\"position\": 3}),\n",
+    "    coords={\n",
+    "        \"source_position\": source_position,\n",
+    "        \"sample_position\": sample_position,\n",
+    "        \"analyzer_position\": analyzer_position,\n",
+    "        \"position\": position,\n",
+    "    },\n",
+    ")\n",
+    "qens_data"
    ]
   },
   {
@@ -85,8 +127,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L1 = sc.norm(data.coords[\"sample_position\"] - data.coords[\"source_position\"])\n",
-    "L2 = sc.norm(data.coords[\"position\"] - data.coords[\"sample_position\"])\n",
+    "L1 = sc.norm(elastic_data.coords[\"sample_position\"] - elastic_data.coords[\"source_position\"])\n",
+    "L2 = sc.norm(elastic_data.coords[\"position\"] - elastic_data.coords[\"sample_position\"])\n",
+    "Ltotal = L1 + L2\n",
+    "Ltotal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "013a4ecc-188c-434d-a75c-8425e3ddc3e2",
+   "metadata": {},
+   "source": [
+    "This uses vector arithmetic on the coordinates and [scipp.norm](https://scipp.github.io/generated/functions/scipp.norm.html) to compute vector lengths.\n",
+    "\n",
+    "However, if we now want to do this for the QENS experiment, we need to rewrite the entire procedure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd2a3af3-3f02-4d1c-b6ca-d39319516a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L1 = sc.norm(qens_data.coords[\"sample_position\"] - qens_data.coords[\"source_position\"])\n",
+    "L2 = (sc.norm(qens_data.coords[\"position\"] - qens_data.coords[\"analyzer_position\"])\n",
+    "     + sc.norm(qens_data.coords[\"analyzer_position\"] - qens_data.coords[\"sample_position\"]))\n",
     "Ltotal = L1 + L2\n",
     "Ltotal"
    ]
@@ -96,12 +162,11 @@
    "id": "b255c737-2ce0-4a63-83d7-b57eabb2483a",
    "metadata": {},
    "source": [
-    "This uses vector arithmetic on the coordinates and [scipp.norm](https://scipp.github.io/generated/functions/scipp.norm.html) to compute vector lengths.\n",
+    "## Using `transform_coords`\n",
     "\n",
-    "## Less pedestrian: using functions\n",
+    "Instead, we are going to use [scipp.transform_coords](https://scipp.github.io/generated/functions/scipp.transform_coords.html).\n",
     "\n",
-    "However, if we now want to do this for the QENS experiment, we need to rewrite the entire procedure.\n",
-    "To avoid this, let us define some functions and use those to compute the sample `Ltotal` as before:"
+    "First, we have to define functions to compute `Ltotal` and its components `L1` and `L2`:"
    ]
   },
   {
@@ -124,42 +189,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6fe72cd2-c9cb-4f3b-b96d-50997dd1a0e4",
+   "metadata": {},
+   "source": [
+    "We then store those functions in a `dict`.\n",
+    "The `dict`-keys are names for the outputs of the functions."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "33e0e186-5968-4209-8454-a89f1511530e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "L1 = straight_l1(\n",
-    "    source_position=data.coords[\"source_position\"],\n",
-    "    sample_position=data.coords[\"sample_position\"],\n",
-    ")\n",
-    "L2 = straight_l2(\n",
-    "    sample_position=data.coords[\"sample_position\"],\n",
-    "    position=data.coords[\"position\"],\n",
-    ")\n",
-    "Ltotal = l_total(L1=L1, L2=L2)\n",
-    "Ltotal"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "decb17ab-6fb1-4bca-8435-eb5f17abfcef",
-   "metadata": {},
-   "source": [
-    "We could now define a function for backscattering.\n",
-    "But we would still need to rewrite the 2nd cell above.\n",
-    "\n",
-    "## Using `transform_coords`\n",
-    "\n",
-    "Instead, we are going to use [scipp.transform_coords](https://scipp.github.io/generated/functions/scipp.transform_coords.html).\n",
-    "First, we have to store our functions in a `dict`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "adc593c7-7b66-4cfe-bd23-0e38b87e6bc1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,9 +212,7 @@
    "id": "c7e58979-0e13-4f85-a1af-d65cb5f22ed8",
    "metadata": {},
    "source": [
-    "The `dict`-keys are names for the outputs of the functions.\n",
-    "\n",
-    "This dict can be seen as defining a graph that connects coordinates with functions that can compute them.\n",
+    "This dict defines a graph that connects coordinates with functions that can compute them.\n",
     "We can visualize it with Scipp:"
    ]
   },
@@ -205,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "converted = data.transform_coords(\"Ltotal\", graph=graph)\n",
+    "converted = elastic_data.transform_coords(\"Ltotal\", graph=graph)\n",
     "converted"
    ]
   },
@@ -218,19 +257,7 @@
     "\n",
     "- It computed `Ltotal` as we requested and stored it as a new coordinate.\n",
     "- It also computed `L1` and `L2` because those were needed for `Ltotal`.\n",
-    "- It renamed the dimension from `position` to `Ltotal` because we consider the latter to have replaced the former.\n",
-    "\n",
-    "It is also possible to compute other values than `Ltotal`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3d5fc962-9397-41c5-b8a4-9b6e55bc24f4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.transform_coords(\"L1\", graph=graph)"
+    "- It renamed the dimension from `position` to `Ltotal` because we consider the latter to have replaced the former."
    ]
   },
   {
@@ -238,52 +265,10 @@
    "id": "761466c7-0e84-4696-b430-752e8f2db214",
    "metadata": {},
    "source": [
-    "## Customizing the graph\n",
+    "### Customizing the graph for QENS\n",
     "\n",
     "We can now adapt the above example to compute `Ltotal` for the `QENS` experiment.\n",
-    "First, generate some new test data.\n",
-    "This is similar to before but now includes `analyzer_position`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0053446e-5707-4652-8d1e-6cd6fe767890",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "source_position = sc.vector([0.0, 0.0, -10.0], unit=\"m\")\n",
-    "sample_position = sc.vector([0.0, 0.0, 0.0], unit=\"m\")\n",
-    "analyzer_position = sc.vector([0.0, 1.0, 1.0], unit=\"m\")\n",
-    "position = sc.vectors(\n",
-    "    dims=[\"position\"],\n",
-    "    values=[\n",
-    "        [0.0, 1.9, 0.0],\n",
-    "        [0.0, 2.0, 0.0],\n",
-    "        [0.0, 2.1, 0.0],\n",
-    "    ],\n",
-    "    unit=\"m\",\n",
-    ")\n",
-    "\n",
-    "qens_data = sc.DataArray(\n",
-    "    sc.ones(sizes={\"position\": 3}),\n",
-    "    coords={\n",
-    "        \"source_position\": source_position,\n",
-    "        \"sample_position\": sample_position,\n",
-    "        \"analyzer_position\": analyzer_position,\n",
-    "        \"position\": position,\n",
-    "    },\n",
-    ")\n",
-    "qens_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6e5dd80d-7a90-4814-8274-82ab0c7384e5",
-   "metadata": {},
-   "source": [
-    "Now, define a new function to compute `L2` for the `QENS` beamline.\n",
-    "Remember that `L2` is the length of the flight path from sample to analyzer to detector.\n",
+    "We need a new function that computes `L2` the flight path length from sample to analyzer to detector.\n",
     "\n",
     "![image](../images/qens-beamline.svg)"
    ]
@@ -363,7 +348,7 @@
    "source": [
     "It is similar to our own graph but involves additional intermediate results and can also be used to compute the scattering angle `two_theta`.\n",
     "\n",
-    "We can also add functions to compute the energy transfer in an indirect-geometry inelastic experiment:\n",
+    "We can also add functions to compute the many more coordinates such as $d$-spacing, $Q$, or hkl indices:\n",
     "(If you don't know the syntax, simple read `{**a, **b}` as merging the two dicts `a` and `b` into a single dict.)"
    ]
   },
@@ -376,32 +361,8 @@
    "source": [
     "graph = {\n",
     "    **scn.conversion.graph.beamline.beamline(scatter=True),\n",
-    "    **scn.conversion.graph.tof.indirect_inelastic(start=\"tof\"),\n",
+    "    **scn.conversion.graph.tof.elastic(start=\"tof\"),\n",
     "}\n",
-    "sc.show_graph(graph)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2e7db018-3c1d-4b2a-912e-a1318b72469b",
-   "metadata": {},
-   "source": [
-    "If instead, we were working with an elastic experiment, we could use [scn.conversion.graph.tof.elastic](https://scipp.github.io/scippneutron/generated/modules/scippneutron.conversion.graph.tof.elastic.html) or any other graph provided by [sc.conversion.graph](https://scipp.github.io/scippneutron/generated/modules/scippneutron.conversion.graph.html).\n",
-    "\n",
-    "This graph assumes straight beams as indicated by the function names.\n",
-    "We can adapt it like before for our specific geometry as shown below.\n",
-    "Here, we also remove `scattered_beam` as there is no single 'scattered beam' in this case."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c0ffafd6-9340-4a0b-b38d-d8e0fa194017",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "graph[\"L2\"] = backscattering_l2\n",
-    "del graph[\"scattered_beam\"]\n",
     "sc.show_graph(graph)"
    ]
   }
@@ -422,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #5
This makes the coord transform section a little shorter to squeeze more content into the available schedule.

Note that this PR is currently based on the Python 3.12 update.